### PR TITLE
Introduce fallthrough attribute

### DIFF
--- a/Compress/pgpzlib.cpp
+++ b/Compress/pgpzlib.cpp
@@ -1,5 +1,7 @@
 #include "pgpzlib.h"
 
+#include "../common/compiler.h"
+
 /* Compress from file source to file dest until EOF on source.
    def() returns Z_OK on success, Z_MEM_ERROR if memory could not be
    allocated for processing, Z_STREAM_ERROR if an invalid compression
@@ -129,7 +131,9 @@ int zlib_decompress(const std::string & src, std::string & dst, int windowBits)
             switch (ret) {
             case Z_NEED_DICT:
                 ret = Z_DATA_ERROR;     /* and fall through */
+                FALL_THROUGH;
             case Z_DATA_ERROR:
+                FALL_THROUGH;
             case Z_MEM_ERROR:
                 (void)inflateEnd(&strm);
                 return ret;

--- a/common/compiler.h
+++ b/common/compiler.h
@@ -1,0 +1,22 @@
+#ifndef __COMPILER_H__
+#define __COMPILER_H__
+
+#if defined(__clang__)
+
+# define FALL_THROUGH [[clang::fallthrough]]
+
+#elif defined(__GNUC__)
+
+# if __GNUC__  > 6
+#  define FALL_THROUGH __attribute__ ((fallthrough))
+# else
+#  define FALL_THROUGH
+# endif
+
+#else
+
+# define FALL_THROUGH
+
+#endif
+
+#endif // __COMPILER_H__


### PR DESCRIPTION
This PR introduces the fall through attribute.
We use the OpenPGP library with our own build system and some tighter errors and warnings enabled. When compiling with gcc-7.2 and with `-Wextra` the `-Wimplicit-fallthrough` flag is included. To circumvent the warning when a fall through is wanted the `FALL_THROUGH` attribute is defined.
The compiler specific details are abstracted in the `compiler.h`.