### PR TITLE
Fix warnings

### DIFF
--- a/Compress/Makefile
+++ b/Compress/Makefile
@@ -1,6 +1,6 @@
 # Compression Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 
 include objects.mk
 

--- a/Encryptions/Makefile
+++ b/Encryptions/Makefile
@@ -1,6 +1,6 @@
 # Encryptions Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 
 include objects.mk
 

--- a/Hashes/Makefile
+++ b/Hashes/Makefile
@@ -1,6 +1,6 @@
 # Hashes Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 
 include objects.mk
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # OpenPGP Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 AR=ar
 TARGET=libOpenPGP.a
 

--- a/Message.cpp
+++ b/Message.cpp
@@ -3,7 +3,7 @@
 namespace OpenPGP {
 
 // OpenPGP Message :- Encrypted Message | Signed Message | Compressed Message | Literal Message.
-bool Message::OpenMessage(std::list <Token>::iterator it, std::list <Token> & s){
+bool Message::OpenMessage(std::list <Token>::iterator it, std::list <Token> &){
     if ((*it == ENCRYPTEDMESSAGE) || (*it == SIGNEDMESSAGE) || (*it == COMPRESSEDMESSAGE) || (*it == LITERALMESSAGE)){
         *it = OPENMessage;
         return true;
@@ -12,7 +12,7 @@ bool Message::OpenMessage(std::list <Token>::iterator it, std::list <Token> & s)
 }
 
 // Compressed Message :- Compressed Data Packet.
-bool Message::CompressedMessage(std::list <Token>::iterator it, std::list <Token> & s){
+bool Message::CompressedMessage(std::list <Token>::iterator it, std::list <Token> &){
     if (*it == CDP){
         *it = COMPRESSEDMESSAGE;
         return true;
@@ -21,7 +21,7 @@ bool Message::CompressedMessage(std::list <Token>::iterator it, std::list <Token
 }
 
 // Literal Message :- Literal Data Packet.
-bool Message::LiteralMessage(std::list <Token>::iterator it, std::list <Token> & s){
+bool Message::LiteralMessage(std::list <Token>::iterator it, std::list <Token> &){
     if (*it == LDP){
         *it = LITERALMESSAGE;
         return true;
@@ -30,7 +30,7 @@ bool Message::LiteralMessage(std::list <Token>::iterator it, std::list <Token> &
 }
 
 // ESK :- Public-Key Encrypted Session Key Packet | Symmetric-Key Encrypted Session Key Packet.
-bool Message::EncryptedSessionKey(std::list <Token>::iterator it, std::list <Token> & s){
+bool Message::EncryptedSessionKey(std::list <Token>::iterator it, std::list <Token> &){
     if ((*it == PKESKP) || (*it == SKESKP)){
         *it = ESK;
         return true;
@@ -56,7 +56,7 @@ bool Message::ESKSequence(std::list <Token>::iterator it, std::list <Token> & s)
 }
 
 // Encrypted Data :- Symmetrically Encrypted Data Packet | Symmetrically Encrypted Integrity Protected Data Packet
-bool Message::EncryptedData(std::list <Token>::iterator it, std::list <Token> & s){
+bool Message::EncryptedData(std::list <Token>::iterator it, std::list <Token> &){
     if ((*it == SEDP) || (*it == SEIPDP)){
         *it = ENCRYPTEDDATA;
         return true;

--- a/Misc/Makefile
+++ b/Misc/Makefile
@@ -1,6 +1,6 @@
 # Misc Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 
 include objects.mk
 

--- a/PGP.h
+++ b/PGP.h
@@ -95,7 +95,7 @@ namespace OpenPGP {
             PGP(const PGP & copy);                          // clone another PGP instance
             PGP(const std::string & data);
             PGP(std::istream & stream);
-            ~PGP();
+            virtual ~PGP();
 
             // Read ASCII Header + Base64 data
             void read(const std::string & data);

--- a/PKA/Makefile
+++ b/PKA/Makefile
@@ -1,6 +1,6 @@
 # PKA Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 
 include objects.mk
 

--- a/Packets/Makefile
+++ b/Packets/Makefile
@@ -1,6 +1,6 @@
 # Packets Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 
 include objects.mk
 

--- a/RNG/Makefile
+++ b/RNG/Makefile
@@ -1,6 +1,6 @@
 # RNG Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 
 include objects.mk
 

--- a/Subpackets/Makefile
+++ b/Subpackets/Makefile
@@ -1,6 +1,6 @@
 # Subpackets Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 
 include objects.mk
 

--- a/Subpackets/Tag17/Makefile
+++ b/Subpackets/Tag17/Makefile
@@ -1,6 +1,6 @@
 # Subpackets Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 
 include objects.mk
 

--- a/Subpackets/Tag2/Makefile
+++ b/Subpackets/Tag2/Makefile
@@ -1,6 +1,6 @@
 # Subpackets Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 
 include objects.mk
 

--- a/Subpackets/Tag2/Sub29.cpp
+++ b/Subpackets/Tag2/Sub29.cpp
@@ -5,8 +5,7 @@ namespace Subpacket {
 namespace Tag2 {
 
 bool Revoke::is_key_revocation(const uint8_t code){
-    return ((NO_REASON_SPECIFIED <= code) &&
-            (code <= KEY_IS_NO_LONGER_USED));
+    return code <= KEY_IS_NO_LONGER_USED;
 }
 
 Sub29::Sub29()

--- a/common/Makefile
+++ b/common/Makefile
@@ -1,6 +1,6 @@
 # common Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 
 include objects.mk
 

--- a/decrypt.cpp
+++ b/decrypt.cpp
@@ -23,7 +23,7 @@ Message data(const uint8_t sym,
         return Message();
     }
 
-    uint8_t tag;
+    uint8_t tag = Packet::RESERVED;
     std::string data = "";
 
     // copy initial data to string

--- a/exec/Makefile
+++ b/exec/Makefile
@@ -1,6 +1,6 @@
 # OpenPGP executable Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall
+CXXFLAGS=-std=c++11 -Wall -Wextra
 LDFLAGS=-lOpenPGP -lgmp -lgmpxx -lbz2 -lz -L..
 TARGET=OpenPGP
 

--- a/exec/modules/Makefile
+++ b/exec/modules/Makefile
@@ -1,6 +1,6 @@
 # OpenPGP executable modules Makefile
 CXX?=g++
-CXXFLAGS=-std=c++11 -Wall -c
+CXXFLAGS=-std=c++11 -Wall -Wextra -c
 
 include objects.mk
 

--- a/sign.cpp
+++ b/sign.cpp
@@ -368,7 +368,7 @@ Packet::Tag2::Ptr subkey_binding(const Packet::Tag5::Ptr & primary, const std::s
 }
 
 // 0x19: Primary Key Binding Signature
-Packet::Tag2::Ptr primary_key_binding(const Args & args, const PublicKey & signee){
+Packet::Tag2::Ptr primary_key_binding(const Args & args, const PublicKey &){
     if (!args.valid()){
         // "Error: Bad arguments.\n";
         return nullptr;


### PR DESCRIPTION
This PR fixes various warnings during the build process, namely:
* unused-parameter
* maybe-uninitialized
* non-virtual-dtor
* type-limits

and enables the -Wextra compiler flag for the build process.